### PR TITLE
fix gettid type on Ubuntu 20.04

### DIFF
--- a/src/lib/get_tid.c
+++ b/src/lib/get_tid.c
@@ -7,6 +7,6 @@
 #include <asm/unistd.h>
 #include "get_tid.h"
 
-long int gettid() {
+__pid_t gettid() {
 	return (pid_t)syscall(__NR_gettid);
 }

--- a/src/lib/get_tid.h
+++ b/src/lib/get_tid.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-long int gettid();
+__pid_t gettid();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fix for conflicting data type
```
In file included from /home/mk/code/USBProxy-legacy/src/lib/RelayWriter.cpp:14:
/home/mk/code/USBProxy-legacy/src/lib/get_tid.h:12:10: error: conflicting declaration of C function ‘long int gettid()’
   12 | long int gettid();
      |          ^~~~~~
In file included from /usr/include/unistd.h:1170,
                 from /home/mk/code/USBProxy-legacy/src/lib/RelayWriter.cpp:7:
/usr/include/x86_64-linux-gnu/bits/unistd_ext.h:34:16: note: previous declaration ‘__pid_t gettid()’
   34 | extern __pid_t gettid (void) __THROW;
      |                ^~~~~~
```